### PR TITLE
ci: use reusable workflows from IndrajeetPatil/workflows

### DIFF
--- a/.github/workflows/build-presentation.yaml
+++ b/.github/workflows/build-presentation.yaml
@@ -6,71 +6,10 @@ on:
   pull_request:
     branches: [main, master]
 
-permissions:
-  contents: read
-
 jobs:
-  build-presentation:
-    runs-on: ubuntu-latest
+  build-and-deploy:
+    uses: IndrajeetPatil/workflows/.github/workflows/build-presentation-python.yaml@main
     permissions:
       contents: read
       pages: write
       id-token: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
-
-      - name: Set up Python
-        run: uv python install
-
-      - name: Setup Quarto
-        uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b # v2.2.0
-
-      - name: Setup Pandoc (latest)
-        uses: r-lib/actions/setup-pandoc@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
-        with:
-          pandoc-version: latest
-
-      - name: Install Quarto extensions
-        run: |
-          quarto --version
-          pandoc --version | head -n 1
-          quarto install extension quarto-ext/fontawesome --no-prompt
-
-      - name: Install dependencies
-        run: uv sync --frozen --no-install-project
-
-      - name: Render slides
-        run: |
-          PANDOC_DIR="$(dirname "$(command -v pandoc)")"
-          QUARTO_PANDOC="$PANDOC_DIR" uv run --no-project quarto render
-
-      - name: Configure GitHub Pages
-        if: github.event_name != 'pull_request'
-        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-        with:
-          enablement: true
-
-      - name: Upload Pages artifact
-        if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
-        with:
-          path: _site
-
-  deploy:
-    if: github.event_name != 'pull_request'
-    needs: build-presentation
-    runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/update-extensions.yaml
+++ b/.github/workflows/update-extensions.yaml
@@ -5,21 +5,9 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   update:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Quarto
-        uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b # v2.2.0
-
-      - name: Update Quarto extensions
-        uses: mcanouil/quarto-extensions-updater@7d06ddf3644441a874bbb8a0fddaba0b67ab71d6 # v2.1.1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+    uses: IndrajeetPatil/workflows/.github/workflows/update-extensions.yaml@main
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
## Summary

Migrates from standalone workflows to reusable workflows in [IndrajeetPatil/workflows](https://github.com/IndrajeetPatil/workflows).

### Changes
- `build-presentation.yaml`: Replaced with call to `build-presentation-python.yaml` reusable workflow
- `update-extensions.yaml`: Replaced with call to `update-extensions.yaml` reusable workflow
- Migrates from macOS runner to Ubuntu (cheaper, faster)
- Migrates from JamesIves branch deployment to official GitHub Pages deployment
- All actions now pinned to SHA for supply chain security
- `astral-sh/setup-uv` upgraded from v7 → v8.0.0
- `mcanouil/quarto-extensions-updater` upgraded to v2.1.1

### ⚠️ Action Required
After merging, update GitHub Pages settings:
1. Go to **Settings → Pages**
2. Under **Source**, change from **Deploy from a branch** to **GitHub Actions**

### Benefits
- Centralized workflow maintenance
- SHA-pinned actions for security
- Consistent CI/CD across all presentation repos

### Note on `@main` references

The caller workflows reference `IndrajeetPatil/workflows` via `@main` rather than a pinned SHA. This is intentional — all third-party GitHub Actions within the reusable workflows are already pinned to specific commit SHAs (e.g., `actions/checkout@de0fac2...`, `r-lib/actions@6f6e5bc...`). Since the workflows repository is under the same owner's control, there is no third-party supply chain risk. This follows the same pattern used by [easystats/workflows](https://github.com/easystats/workflows).