### PR TITLE
chore: use grouped dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,8 +1,24 @@
 version: 2
 
 updates:
+  # Keep Python dependencies up-to-date
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
   # Keep dependencies for GitHub Actions up-to-date
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+    groups:
+      all-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Propagates the grouped dependabot configuration from `parse-dont-pray`:

- Groups all `uv` (Python) dependency updates into a single weekly PR
- Groups all GitHub Actions updates into a single weekly PR
- Sets Monday as the update day for both ecosystems

This reduces PR noise by batching related dependency updates together.