### PR TITLE
chore: replace old GitHub Pages domain with new custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ The title is inspired by the following quote:
 > \- Phil Karlton
 
 The slides can be seen here:<br>
-<https://indrajeetpatil.github.io/second-hardest-cs-thing/>
+<https://www.indrapatil.com/second-hardest-cs-thing/>
 
-<a href="https://indrajeetpatil.github.io/second-hardest-cs-thing/" target="_blank">
+<a href="https://www.indrapatil.com/second-hardest-cs-thing/" target="_blank">
 <img src="media/cat.png" alt="introductory slide" width="400"/>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The title is inspired by the following quote:
 The slides can be seen here:<br>
 <https://www.indrapatil.com/second-hardest-cs-thing/>
 
-<a href="https://www.indrapatil.com/second-hardest-cs-thing/" target="_blank">
+<a href="https://www.indrapatil.com/second-hardest-cs-thing/" target="_blank" rel="noopener noreferrer">
 <img src="media/cat.png" alt="introductory slide" width="400"/>
 </a>
 

--- a/index.qmd
+++ b/index.qmd
@@ -26,7 +26,7 @@ lang: "en"
 dir: "ltr"
 image: "media/social-media-card.png"
 image-alt: "Preview image for presentation about naming things in computer science"
-canonical-url: "https://indrajeetpatil.github.io/second-hardest-cs-thing/"
+canonical-url: "https://www.indrapatil.com/second-hardest-cs-thing/"
 jupyter: python3
 ---
 
@@ -1189,7 +1189,7 @@ And Happy Naming! 😊
 
 ::: {style="text-align: center; font-size: 0.7em;"}
 
-Check out my other [slide decks](https://indrajeetpatil.github.io/presentations/) on software development best practices
+Check out my other [slide decks](https://www.indrapatil.com/presentations/) on software development best practices
 
 :::
 

--- a/meta-tags.html
+++ b/meta-tags.html
@@ -23,11 +23,11 @@
 />
 <meta
   property="og:image"
-  content="https://indrajeetpatil.github.io/second-hardest-cs-thing/media/social-media-card.png"
+  content="https://www.indrapatil.com/second-hardest-cs-thing/media/social-media-card.png"
 />
 <meta
   property="og:url"
-  content="https://indrajeetpatil.github.io/second-hardest-cs-thing/"
+  content="https://www.indrapatil.com/second-hardest-cs-thing/"
 />
 <meta property="og:type" content="website" />
 <meta name="twitter:card" content="summary_large_image" />
@@ -41,5 +41,5 @@
 />
 <meta
   name="twitter:image"
-  content="https://indrajeetpatil.github.io/second-hardest-cs-thing/media/social-media-card.png"
+  content="https://www.indrapatil.com/second-hardest-cs-thing/media/social-media-card.png"
 />


### PR DESCRIPTION
## Summary

This PR updates all references from the old GitHub Pages domain to the new custom domain:

- **Old**: `https://indrajeetpatil.github.io/`
- **New**: `https://www.indrapatil.com/`

This is part of a bulk domain migration across all repositories.