### PR TITLE
[codex] Improve presentation discoverability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ _extensions/
 index.html
 index_files/
 index.quarto_ipynb
+
+**/*.quarto_ipynb

--- a/.well-known/llms-full.txt
+++ b/.well-known/llms-full.txt
@@ -1,0 +1,10 @@
+# Dealing with the Second Hardest Thing in Computer Science
+
+This is the well-known discovery copy for agentic assistants.
+
+Canonical slides: https://www.indrapatil.com/second-hardest-cs-thing/
+Root llms.txt: https://www.indrapatil.com/second-hardest-cs-thing/llms.txt
+Root llms-full.txt: https://www.indrapatil.com/second-hardest-cs-thing/llms-full.txt
+Source: https://github.com/IndrajeetPatil/second-hardest-cs-thing/
+
+Summary: A Quarto RevealJS presentation on naming things in software development. The deck covers why naming is hard, why names affect maintainability, common naming pitfalls, naming principles, Boolean naming, grammatical consistency, tooling limits, AI-assisted naming, code review, and safe renaming in legacy code.

--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -1,0 +1,7 @@
+# Dealing with the Second Hardest Thing in Computer Science
+
+> A Quarto RevealJS presentation by Indrajeet Patil about choosing clear, consistent, and maintainable names in software development.
+
+Canonical slides: https://www.indrapatil.com/second-hardest-cs-thing/
+Full agent summary: https://www.indrapatil.com/second-hardest-cs-thing/llms-full.txt
+Source: https://github.com/IndrajeetPatil/second-hardest-cs-thing/

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,3 +1,11 @@
 project:
   type: default
   output-dir: _site
+  resources:
+    - robots.txt
+    - sitemap.xml
+    - llms.txt
+    - llms-full.txt
+    - .well-known/llms.txt
+    - .well-known/llms-full.txt
+    - media/social-media-card.png

--- a/justfile
+++ b/justfile
@@ -36,15 +36,15 @@ update:
 
 # Render slides
 render:
-    uv run --no-project quarto render index.qmd
+    QUARTO_PYTHON=.venv/bin/python quarto render index.qmd
 
 # Preview with live reload
 preview:
-    uv run --no-project quarto preview index.qmd
+    QUARTO_PYTHON=.venv/bin/python quarto preview index.qmd
 
 # Open rendered slides in browser (macOS)
 open:
-    open index.html
+    open _site/index.html
 
 # Clean generated files
 clean:
@@ -57,4 +57,4 @@ clean:
 
 # Check Quarto setup
 check:
-    uv run --no-project quarto check
+    QUARTO_PYTHON=.venv/bin/python quarto check

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,76 @@
+# Dealing with the Second Hardest Thing in Computer Science
+
+Author: Indrajeet Patil
+Format: Quarto RevealJS presentation
+Canonical URL: https://www.indrapatil.com/second-hardest-cs-thing/
+Source: https://github.com/IndrajeetPatil/second-hardest-cs-thing/
+License: CC0 1.0 Universal
+Publication date: 2025-12-05
+Language: English
+
+## Summary
+
+This slide deck presents practical guidance for naming things in software development. Its central claim is that names should serve code readers, not only code authors. Good names reveal intention, reduce cognitive load, make code review more effective, and lower long-term maintenance risk.
+
+The talk is aimed at software developers, data scientists, code reviewers, maintainers, and technical teams that want more readable and maintainable code. The examples use Python syntax, but the principles apply across programming languages and software domains.
+
+## Learning goals
+
+- Understand why naming affects code quality and maintainability.
+- Recognize common naming pitfalls, including ambiguity, inconsistency, misleading abbreviations, similar-looking names, slang, region-specific terminology, and unsearchable short names.
+- Choose names that are specific, difficult to misinterpret, appropriately abstract, and aligned with language or domain standards.
+- Name Boolean variables and functions so that true and false values are obvious.
+- Use grammatical forms consistently, such as nouns for entities and verbs for actions.
+- Use linters, generative AI, and code review as aids while recognizing their limits.
+- Rename safely in legacy code through deprecation, IDE refactoring tools, small commits, and test runs.
+
+## Core recommendations
+
+- Prefer names that make code self-documenting.
+- Use more descriptive names as scope and complexity increase.
+- Try to misinterpret candidate names before accepting them.
+- Keep important units, encodings, security details, and domain distinctions in names.
+- Remove redundant implementation details when context already provides them.
+- Follow one naming standard consistently within a project.
+- Prefer domain language for business concepts and computer science terminology for technical concepts.
+- Avoid flag parameters when they indicate that a function is doing multiple unrelated things.
+
+## Important examples
+
+- Prefer `fahrenheit_to_celsius(temp_fahrenheit)` over a generic `unit_converter(temp)`.
+- Prefer `inventory[warehouse][product]` over `inventory[i][j]` in long-lived or complex loops.
+- Prefer `get_character_count(file_path)` over `get_size(file_path)` when the return value is not file size in bytes.
+- Prefer `byte_size` and `length` when distinguishing bytes from element counts.
+- Prefer `is_firewall_enabled = True` over `is_firewall_disabled = False` when positive Boolean wording is easier to reason about.
+- Prefer separate functions such as `extract_estimates()` and `sort_estimates()` over a single `extract_and_sort_estimates()` when the function has multiple responsibilities.
+
+## References discussed
+
+- Steve McConnell, Code Complete.
+- Dustin Boswell and Trevor Foucher, The Art of Readable Code.
+- Robert C. Martin, Clean Code.
+- Felienne Hermans, The Programmer's Brain.
+- John Ousterhout, A Philosophy of Software Design.
+- Pete Goodliffe, Code Craft.
+- James Padolsey, Clean Code in JavaScript.
+- Maximiliano Contieri, Clean Code Cookbook.
+- Chris Zimmerman, The Rules of Programming.
+- Ottinger's Rules for Variable and Class Naming.
+- Google C++ Style Guide.
+
+## Useful external naming conventions
+
+- BEM CSS class naming.
+- REST API resource naming.
+- PEP 8 Python naming conventions.
+- Google Java Style Guide.
+- Rust API naming guidelines.
+- Go Code Review Comments.
+- Kubernetes resource naming.
+- SQL style guide naming conventions.
+- Microsoft .NET naming guidelines.
+- Ruby Style Guide.
+
+## Retrieval notes
+
+The canonical HTML page is the primary version of the presentation. This text file exists to give search engines, answer engines, and agentic assistants a concise, non-JavaScript-dependent summary of the deck's content and citation metadata.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,26 @@
+# Dealing with the Second Hardest Thing in Computer Science
+
+> A Quarto RevealJS presentation by Indrajeet Patil about choosing clear, consistent, and maintainable names in software development.
+
+This presentation explains why naming is difficult, how poor names create maintenance costs, and how to choose names that serve future readers of code. The examples are mostly Python-flavoured, but the guidance is language-agnostic.
+
+## Primary URL
+
+- [Slides](https://www.indrapatil.com/second-hardest-cs-thing/)
+
+## Source
+
+- [GitHub repository](https://github.com/IndrajeetPatil/second-hardest-cs-thing/)
+
+## Topics
+
+- Naming things in computer science
+- Code readability and maintainability
+- Variable, function, class, Boolean, and parameter naming
+- Software development conventions
+- Clean code and code review practices
+- Safe renaming in legacy code
+
+## Machine-readable companion
+
+- [Full agent summary](https://www.indrapatil.com/second-hardest-cs-thing/llms-full.txt)

--- a/meta-tags.html
+++ b/meta-tags.html
@@ -30,7 +30,23 @@
   content="https://www.indrapatil.com/second-hardest-cs-thing/"
 />
 <meta property="og:type" content="website" />
+<meta property="og:site_name" content="Indrajeet Patil" />
+<meta property="og:locale" content="en_US" />
+<meta property="og:image:alt" content="Preview image for a presentation about naming things in computer science" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta name="author" content="Indrajeet Patil" />
+<meta name="keywords" content="naming, software engineering, computer science, software development, code readability, clean code, maintainability, programming best practices" />
+<meta name="robots" content="index, follow" />
+<meta name="googlebot" content="max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
+<meta name="citation_author" content="Indrajeet Patil" />
+<meta name="citation_publication_date" content="2025-12-05" />
+<meta name="citation_title" content="Dealing with the Second Hardest Thing in Computer Science" />
+<link rel="ai-content-policy" type="text/plain" href="https://www.indrapatil.com/second-hardest-cs-thing/llms.txt" />
+<link rel="alternate" type="text/markdown" title="llms.txt" href="https://www.indrapatil.com/second-hardest-cs-thing/llms.txt" />
+<link rel="alternate" type="text/markdown" title="llms-full.txt" href="https://www.indrapatil.com/second-hardest-cs-thing/llms-full.txt" />
 <meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:creator" content="@patilindrajeets" />
 <meta
   name="twitter:title"
   content="Dealing with the Second Hardest Thing in Computer Science"
@@ -43,3 +59,97 @@
   name="twitter:image"
   content="https://www.indrapatil.com/second-hardest-cs-thing/media/social-media-card.png"
 />
+<meta name="twitter:image:alt" content="Preview image for a presentation about naming things in computer science" />
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "@id": "https://www.indrapatil.com/#website",
+      "name": "Indrajeet Patil",
+      "url": "https://www.indrapatil.com/",
+      "inLanguage": "en"
+    },
+    {
+      "@type": "PresentationDigitalDocument",
+      "@id": "https://www.indrapatil.com/second-hardest-cs-thing/#presentation",
+      "name": "Dealing with the Second Hardest Thing in Computer Science",
+      "headline": "Dealing with the Second Hardest Thing in Computer Science",
+      "description": "A RevealJS presentation on choosing meaningful, consistent, and maintainable names for variables, functions, classes, APIs, and other software entities.",
+      "url": "https://www.indrapatil.com/second-hardest-cs-thing/",
+      "image": "https://www.indrapatil.com/second-hardest-cs-thing/media/social-media-card.png",
+      "thumbnailUrl": "https://www.indrapatil.com/second-hardest-cs-thing/media/social-media-card.png",
+      "inLanguage": "en",
+      "datePublished": "2025-12-05",
+      "dateModified": "2025-12-05",
+      "encodingFormat": "text/html",
+      "learningResourceType": "presentation",
+      "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+      "isAccessibleForFree": true,
+      "keywords": [
+        "naming",
+        "software engineering",
+        "computer science",
+        "software development",
+        "code readability",
+        "clean code",
+        "maintainability",
+        "programming best practices"
+      ],
+      "about": [
+        "Naming things in computer science",
+        "Code readability",
+        "Software maintainability",
+        "Programming conventions",
+        "Clean code"
+      ],
+      "audience": {
+        "@type": "Audience",
+        "audienceType": "Software developers"
+      },
+      "author": {
+        "@type": "Person",
+        "@id": "https://www.indrapatil.com/#person",
+        "name": "Indrajeet Patil",
+        "url": "https://www.indrapatil.com/",
+        "sameAs": [
+          "https://github.com/IndrajeetPatil",
+          "https://www.linkedin.com/in/indrajeet-patil-ph-d-397865174/"
+        ]
+      },
+      "publisher": {
+        "@id": "https://www.indrapatil.com/#person"
+      },
+      "isPartOf": {
+        "@id": "https://www.indrapatil.com/#website"
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "https://www.indrapatil.com/second-hardest-cs-thing/#breadcrumb",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.indrapatil.com/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Presentations",
+          "item": "https://www.indrapatil.com/presentations/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Dealing with the Second Hardest Thing in Computer Science",
+          "item": "https://www.indrapatil.com/second-hardest-cs-thing/"
+        }
+      ]
+    }
+  ]
+}
+</script>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,25 @@
+User-agent: *
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+Sitemap: https://www.indrapatil.com/second-hardest-cs-thing/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.indrapatil.com/second-hardest-cs-thing/</loc>
+    <lastmod>2025-12-05</lastmod>
+  </url>
+  <url>
+    <loc>https://www.indrapatil.com/second-hardest-cs-thing/llms.txt</loc>
+    <lastmod>2025-12-05</lastmod>
+  </url>
+  <url>
+    <loc>https://www.indrapatil.com/second-hardest-cs-thing/llms-full.txt</loc>
+    <lastmod>2025-12-05</lastmod>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary

This PR improves SEO, GEO, and agentic discoverability for the Quarto RevealJS presentation without changing the slide content.

## Changes

- Adds explicit Quarto `project.resources` entries so crawler and LLM-facing files are copied into `_site/`.
- Adds `robots.txt`, canonical `sitemap.xml`, `llms.txt`, `llms-full.txt`, and `.well-known` LLM discovery files.
- Expands `meta-tags.html` with robots/googlebot directives, richer Open Graph/Twitter metadata, LLM discovery links, citation metadata, and JSON-LD for the presentation, author, website, and breadcrumbs.
- Ensures `media/social-media-card.png` is copied even though it is metadata-only.
- Updates `just render`, `just preview`, and `just check` to use the synced `.venv` Python for Quarto/Jupyter, and fixes `just open` to open `_site/index.html`.
- Ignores generated `*.quarto_ipynb` files consistently.

## Validation

- `just install`
- `just render`
- `just check`
- Parsed emitted JSON-LD from `_site/index.html`
- `xmllint --noout _site/sitemap.xml`
- Verified required rendered resources exist in `_site/`
