### PR TITLE
chore: unify Google Analytics Measurement ID

### DIFF
--- a/meta-tags.html
+++ b/meta-tags.html
@@ -1,7 +1,7 @@
 <!-- Google tag (gtag.js) -->
 <script
   async
-  src="https://www.googletagmanager.com/gtag/js?id=G-LWDD71YD15"
+  src="https://www.googletagmanager.com/gtag/js?id=G-3BQ49J7KYH"
 ></script>
 <script>
   window.dataLayer = window.dataLayer || [];
@@ -10,7 +10,7 @@
   }
   gtag("js", new Date());
 
-  gtag("config", "G-LWDD71YD15");
+  gtag("config", "G-3BQ49J7KYH");
 </script>
 
 <meta


### PR DESCRIPTION
Uses the root domain's Google Analytics Measurement ID for consolidated tracking across all presentations, as per best practices.