### PR TITLE
[codex] Standardize presentation README development docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,47 +14,37 @@ The slides can be seen here:<br>
 <img src="media/cat.png" alt="introductory slide" width="400"/>
 </a>
 
-# Development
+## Development
 
-This project uses Python 3.14+ with [uv](https://docs.astral.sh/uv/) for dependency management, [Quarto](https://quarto.org/) for rendering slides, and [just](https://github.com/casey/just) as a command runner.
+This project uses Python 3.14 (see `.python-version`) with [uv](https://docs.astral.sh/uv/) for dependency management, [Quarto](https://quarto.org/) for rendering slides, and [just](https://github.com/casey/just) as a command runner.
 
-## Prerequisites
+### Prerequisites
 
 ```bash
 # Install just (macOS)
 brew install just
 ```
 
-## Setup
+### Setup
 
 ```bash
-# Install dependencies
 just install
-
-# Or update to latest versions
-just update
 ```
 
-## Common Commands
+### Just Commands
 
 ```bash
-just help      # Show all available commands
-just render    # Render slides to HTML
-just preview   # Live preview with auto-reload
-just open      # Open rendered slides in browser
-just clean     # Remove generated files
-just check     # Check Quarto and Python setup
-just           # Install, render, and open slides (default)
+just help     # Show all available commands
+just install  # Install Quarto extensions and Python dependencies
+just update   # Update Quarto extensions and Python dependencies
+just render   # Render slides to HTML
+just preview  # Start a live preview with auto-reload
+just open     # Open rendered slides in the default browser
+just clean    # Remove generated files and caches
+just check    # Check the Quarto and Python setup
+just          # Install dependencies, render, and open slides
 ```
 
-## GitHub Pages deployment (automatic)
+## Feedback
 
-This repository uses GitHub Actions to render the slides and deploy the rendered `_site/` directory to GitHub Pages.
-
-# Feedback
-
-I'd love to hear thoughts and comments [here](https://github.com/IndrajeetPatil/second-hardest-cs-thing/issues).
-
-# Code of Conduct
-
-Please note that the second-hardest-cs-thing project is released with a [Contributor Code of Conduct](https://www.contributor-covenant.org/version/3/0/code_of_conduct/). By contributing to this project, you agree to abide by its terms.
+Feedback and suggestions are welcome in [the issue tracker](https://github.com/IndrajeetPatil/second-hardest-cs-thing/issues).


### PR DESCRIPTION
## Summary

- standardize README Development and Feedback sections
- remove Code of Conduct and automatic GitHub Pages deployment sections where present
- document only just commands that exist in the repository
- align Python version notes with `.python-version`

## Validation

- verified README just commands against the repository justfile
- ran `just --summary`
